### PR TITLE
Remove "false" answer option.

### DIFF
--- a/code/foundation-exam/parse.rkt
+++ b/code/foundation-exam/parse.rkt
@@ -152,18 +152,16 @@
     ((element* option
                ((identifier identifier)
                 (correct correct-value)
-                (false false-value)
                 (distractor distractor-value))
                (((text) texts)))
      (pick-option
-      (parse-option-validity correct-value false-value distractor-value)
+      (parse-option-validity correct-value distractor-value)
       identifier
       (parse-texts texts)))))
 
-(define (parse-option-validity correct-value false-value distractor-value)
+(define (parse-option-validity correct-value distractor-value)
   (cond
     ((equal? correct-value "correct") 'correct)
-    ((equal? false-value "false") 'false)
     ((equal? distractor-value "distractor") 'distractor)))
 
 (define (parse-category xml)
@@ -224,7 +222,7 @@
        '(("de" . "Genau eine für alle Arten von Systemen.")
          ("en" . "Exactly one for all kinds of systems."))))
      (pick-option
-      'false
+      'distractor
       "B"
       (localized-text
        '(("de"

--- a/code/foundation-exam/print-asciidoc.rkt
+++ b/code/foundation-exam/print-asciidoc.rkt
@@ -283,12 +283,12 @@
          "\n      The variety of definitions of software architecture results, among other things, from different perspectives, target groups and development methods.\n    ")))
      (list
       (pick-option
-       'false
+       'distractor
        "A"
        (localized-text
         '(("de" . "\n        Genau eine für alle Arten von Systemen.\n      ") ("en" . "\n        Exactly one for all kinds of systems.\n      "))))
       (pick-option
-       'false
+       'distractor
        "B"
        (localized-text
         '(("de"
@@ -346,13 +346,13 @@
         '(("de" . "\n        (interne und externe) Schnittstellen\n      ")
           ("en" . "\n        (internal and external) Interfaces\n      "))))
       (pick-option
-       'false
+       'distractor
        "D"
        (localized-text
         '(("de" . "\n        Programmierkonventionen (\"coding conventions\")\n      ")
           ("en" . "\n        Coding conventions\n      "))))
       (pick-option
-       'false
+       'distractor
        "E"
        (localized-text
         '(("de" . "\n        Hardware-Sizing\n      ")

--- a/code/foundation-exam/print.rkt
+++ b/code/foundation-exam/print.rkt
@@ -173,12 +173,12 @@
          "The variety of definitions of software architecture results, among other things, from different perspectives, target groups and development methods.")))
      (list
       (pick-option
-       'false
+       'distractor
        "A"
        (localized-text
         '(("de" . "Genau eine für alle Arten von Systemen.") ("en" . "Exactly one for all kinds of systems."))))
       (pick-option
-       'false
+       'distractor
        "B"
        (localized-text
         '(("de"

--- a/code/foundation-exam/question.rkt
+++ b/code/foundation-exam/question.rkt
@@ -43,7 +43,7 @@
   (or/c "en" "de")) ; at the moment
 
 (struct pick-option
-  (validity ; 'distractor, 'false, or 'correct
+  (validity ; 'distractor, or 'correct
    identifier
    text)
   #:transparent #:mutable)
@@ -107,7 +107,7 @@
   (lang/c contract?)
 
   (struct pick-option
-    ((validity (or/c 'distractor 'false 'correct))
+    ((validity (or/c 'distractor 'correct))
      (identifier string?)
      (text localized-text?)))
 

--- a/exam.rng
+++ b/exam.rng
@@ -105,9 +105,6 @@
 	    <attribute name="distractor">
 	      <value>distractor</value>
 	    </attribute>
-	    <attribute name="false">
-	      <value>false</value>
-	    </attribute>
 	    <attribute name="correct">
 	      <value>correct</value>
 	    </attribute>

--- a/mock/questions/mock-01.xml
+++ b/mock/questions/mock-01.xml
@@ -37,7 +37,7 @@
         Exactly one for all kinds of systems.
       </text>
     </option>
-    <option false="false" identifier="B">
+    <option distractor="distractor" identifier="B">
       <text xml:lang="de">
         Eine für jede Art von Softwaresystem (z. B. "eingebettet","Echtzeit", "Entscheidungsunterstützung", "Web", "Batch", …).
       </text>

--- a/mock/questions/mock-30.xml
+++ b/mock/questions/mock-30.xml
@@ -20,17 +20,17 @@
       <text xml:lang="en">The technical context contains the physical channels between your system and its environment.</text>
     </option>
 
-    <option false="false" identifier="B">
+    <option distractor="distractor" identifier="B">
       <text xml:lang="de">Der technische Kontext enthält die gesamte Infrastruktur, über die die Komponenten Ihres Systems verteilt werden.</text>
       <text xml:lang="en">The technical context contains all the infrastructure on which the components of your system are deployed.</text>
     </option>
 
-    <option false="false" identifier="C">
+    <option distractor="distractor" identifier="C">
       <text xml:lang="de">Der technische Kontext sollte die Hardware-Preisliste oder die Preisgestaltung von Cloud-Diensten, die als Infrastruktur für Ihre Architektur verwendet werden, enthalten.</text>
       <text xml:lang="en">The technical context should include hardware pricing or pricing of cloud services used as infrastructure for your architecture.</text>
     </option>
 
-    <option false="false" identifier="D">
+    <option distractor="distractor" identifier="D">
       <text xml:lang="de">Der technische Kontext enthält Informationen zur gewählten Programmiersprache sowie allen zur Implementierung Ihrer Softwarearchitektur verwendeten Frameworks.</text>
       <text xml:lang="en">The technical context contains information about the chosen programming language as well as all frameworks used to implement your software architecture.</text>
     </option>

--- a/pool/active-group/active-group-01.xml
+++ b/pool/active-group/active-group-01.xml
@@ -29,7 +29,7 @@
         Version of the programming language
       </text>
     </option>
-    <option false="false" identifier="B">
+    <option distractor="distractor" identifier="B">
       <text xml:lang="de">
         Modellierung der Daten
       </text>

--- a/pool/active-group/active-group-05.xml
+++ b/pool/active-group/active-group-05.xml
@@ -19,7 +19,7 @@
   </stem>
 
   <pickOptions>
-    <option false="false" identifier="A">
+    <option distractor="distractor" identifier="A">
       <text xml:lang="de">
         Am Anfang
       </text>
@@ -35,7 +35,7 @@
         Continuous
       </text>
     </option>
-    <option false="false" identifier="C">
+    <option distractor="distractor" identifier="C">
       <text xml:lang="de">
         Am Ende.
       </text>
@@ -43,7 +43,7 @@
         At the end
       </text>
     </option>
-    <option false="false" identifier="D">
+    <option distractor="distractor" identifier="D">
       <text xml:lang="de">
         Am Anfang und am Ende.
       </text>

--- a/pool/active-group/active-group-12.xml
+++ b/pool/active-group/active-group-12.xml
@@ -19,7 +19,7 @@
   </stem>
 
   <pickOptions>
-    <option false="false" identifier="A">
+    <option distractor="distractor" identifier="A">
       <text xml:lang="de">
         Anforderungen formulieren
       </text>
@@ -27,7 +27,7 @@
         Formulating requirements
       </text>
     </option>
-    <option false="false" identifier="B">
+    <option distractor="distractor" identifier="B">
       <text xml:lang="de">
         Leitung des Teams und Kontrolle aller Abläufe
       </text>
@@ -43,7 +43,7 @@
         Assist implementation of the architecture
       </text>
     </option>
-    <option false="false" identifier="D">
+    <option distractor="distractor" identifier="D">
       <text xml:lang="de">
         Testabläufe der Gesamtanwendung definieren und kontrollieren
       </text>

--- a/pool/active-group/active-group-14.xml
+++ b/pool/active-group/active-group-14.xml
@@ -35,7 +35,7 @@
         With up to 1000 parallel accesses, each page accessed should be displayed within one second.
       </text>
     </option>
-    <option false="false" identifier="C">
+    <option distractor="distractor" identifier="C">
       <text xml:lang="de">
         Die Anwendung soll stabil und möglichst unterbrechungsfrei laufen.
       </text>
@@ -44,7 +44,7 @@
       </text>
     </option>
 
-    <option false="false" identifier="D">
+    <option distractor="distractor" identifier="D">
       <text xml:lang="de">
         Zu viele Anfragen des selben Benutzers sollen keinen Einfluss auf die Performance für andere
         Benutzer haben.

--- a/pool/active-group/active-group-19.xml
+++ b/pool/active-group/active-group-19.xml
@@ -28,7 +28,7 @@
                 Scalability
             </text>
         </option>
-        <option false="false" identifier="B">
+        <option distractor="distractor" identifier="B">
             <text xml:lang="de">
                 Redundanz
             </text>
@@ -36,7 +36,7 @@
                 Redundancy
             </text>
         </option>
-        <option false="false" identifier="C">
+        <option distractor="distractor" identifier="C">
             <text xml:lang="de">
                 Isolation
             </text>

--- a/pool/active-group/active-group-22.xml
+++ b/pool/active-group/active-group-22.xml
@@ -25,7 +25,7 @@
                 Recreates the functionality without modification or extension
             </text>
         </option>
-        <option false="false" identifier="B">
+        <option distractor="distractor" identifier="B">
             <text xml:lang="de">
                 Kann nur alleinstehend betrieben werden
             </text>
@@ -42,7 +42,7 @@
             </text>
         </option>
 
-        <option false="false" identifier="D">
+        <option distractor="distractor" identifier="D">
             <text xml:lang="de">
                 Wird nie direkt angesprochen
             </text>

--- a/pool/active-group/active-group-33.xml
+++ b/pool/active-group/active-group-33.xml
@@ -26,7 +26,7 @@
                 … be individually addressed to different target groups.
             </text>
         </option>
-        <option false="false" identifier="B">
+        <option distractor="distractor" identifier="B">
             <text xml:lang="de">
                 … einer vorgegebenen Form entsprechen.
             </text>
@@ -34,7 +34,7 @@
                 … correspond to a given shape.
             </text>
         </option>
-        <option false="false" identifier="C">
+        <option distractor="distractor" identifier="C">
             <text xml:lang="de">
                 … bilateral sein.
             </text>
@@ -43,7 +43,7 @@
             </text>
         </option>
 
-        <option false="false" identifier="D">
+        <option distractor="distractor" identifier="D">
             <text xml:lang="de">
                 … weisungsgebunden sein.
             </text>

--- a/pool/active-group/active-group-34.xml
+++ b/pool/active-group/active-group-34.xml
@@ -26,7 +26,7 @@
                 a structural form for project-related communication
             </text>
         </option>
-        <option false="false" identifier="B">
+        <option distractor="distractor" identifier="B">
             <text xml:lang="de">
                 ein Model zur iterativen Softwareentwicklung
             </text>

--- a/pool/active-group/active-group-36.xml
+++ b/pool/active-group/active-group-36.xml
@@ -18,7 +18,7 @@
     </stem>
 
     <pickOptions>
-        <option false="false" identifier="A">
+        <option distractor="distractor" identifier="A">
             <text xml:lang="de">
                 entsprechend der verschiedenen Anforderungen
             </text>
@@ -34,7 +34,7 @@
                 regarding business and technical context
             </text>
         </option>
-        <option false="false" identifier="C">
+        <option distractor="distractor" identifier="C">
             <text xml:lang="de">
                 zwischen erforderlichem und optionalem Kontext
             </text>
@@ -42,7 +42,7 @@
                 between required and optional contextetween required and optional context
             </text>
         </option>
-        <option false="false" identifier="D">
+        <option distractor="distractor" identifier="D">
             <text xml:lang="de">
                 entsprechend der Einordnung im Gesamtsystem
             </text>

--- a/pool/active-group/active-group-38.xml
+++ b/pool/active-group/active-group-38.xml
@@ -26,7 +26,7 @@
                 internal interfaces
             </text>
         </option>
-        <option false="false" identifier="B">
+        <option distractor="distractor" identifier="B">
             <text xml:lang="de">
                 externe Schnittstellen
             </text>


### PR DESCRIPTION
With a heavy heart, to avoid confusion:

Consistently use "distractor" for incorrect multiple-choice options.
