### PR TITLE
Fix Q37 - qualitative analysis vs. evaluation

### DIFF
--- a/mock/questions/mock-37.xml
+++ b/mock/questions/mock-37.xml
@@ -12,10 +12,10 @@
 
   <stem>
     <text xml:lang="de">
-      Welche vier der folgenden Punkte sind am besten geeignet, die Analyse der Erreichung der Qualitätsanforderungen (qualitative Analyse) Ihrer Softwarearchitektur zu unterstützen?
+      Welche der vier folgenden Punkte sind am besten geeignet, die qualitative Bewertung einer Softwarearchitektur bzgl. der Erfüllung von Qualitätsanforderungen zu unterstützen?
     </text>
     <text xml:lang="en">
-      Which four of the following are best suited to support the analysis of the achievement of the quality requirements (qualitative analysis) of your software architecture? Pick the four best alternatives.
+      Which of the following four points are best suited to support the qualitative evaluation of a software architecture with regard to the fulfillment of quality requirements?
     </text>
   </stem>
 


### PR DESCRIPTION
Fixes #14

Use term "qualitative evaluation" instead of "qualitative analysis"
Do not mix qualitative analysis and quality requirements
