### PR TITLE
Active group exam fixes

### DIFF
--- a/pool/active-group/active-group-09.xml
+++ b/pool/active-group/active-group-09.xml
@@ -33,7 +33,7 @@
     </categories>
 
     <statements>
-      <statement correctCategory="a" identifier="A">
+      <statement correctCategory="b" identifier="A">
         <text xml:lang="de">
           Es ist unmöglich, die Architektur zu dokumentieren.
         </text>

--- a/pool/active-group/active-group-20.xml
+++ b/pool/active-group/active-group-20.xml
@@ -32,7 +32,7 @@
         </categories>
 
         <statements>
-            <statement correctCategory="b" identifier="A">
+            <statement correctCategory="a" identifier="A">
                 <text xml:lang="de">
                     Einfluss von Qualitätsanforderungen
                 </text>

--- a/pool/active-group/active-group-29.xml
+++ b/pool/active-group/active-group-29.xml
@@ -88,7 +88,7 @@
               Maintainability
             </text>
           </statement>
-          <statement correctCategory="a" identifier="H">
+          <statement correctCategory="b" identifier="H">
             <text xml:lang="de">
               Vertikale Modularisierung
             </text>

--- a/pool/active-group/active-group-31.xml
+++ b/pool/active-group/active-group-31.xml
@@ -11,10 +11,10 @@
 
     <stem>
         <text xml:lang="de">
-            Welche der folgenden Antworten sind Design Tactics zur Verbesserung von Performance?
+            Welche der folgenden Antworten sind Taktiken zur Verbesserung von Performance?
         </text>
         <text xml:lang="en">
-            Which of the following are design tactics to improve performance?
+            Which of the following are tactics to improve performance?
         </text>
     </stem>
 

--- a/pool/active-group/active-group-34.xml
+++ b/pool/active-group/active-group-34.xml
@@ -42,8 +42,7 @@
                 a graphical modeling language
             </text>
         </option>
-
-        <option correct="correct" identifier="D">
+        <option correct="distractor" identifier="D">
             <text xml:lang="de">
                 eine Strukturierungsschicht für Prozesse
             </text>


### PR DESCRIPTION
It seems that while importing the questions/answers to the isaqb-repo some copy/paste errors were made. This hopefully fixes some/all of them. Besides, it removes vocabulary that was removed from the isaqb-curriculum---the respective question can exist without the wording.